### PR TITLE
Add question text support and improve PDF

### DIFF
--- a/src/lib/cloudinary/cloudinary.service.ts
+++ b/src/lib/cloudinary/cloudinary.service.ts
@@ -23,7 +23,7 @@ export class CloudinaryService {
           error: UploadApiErrorResponse | undefined,
           result: UploadApiResponse,
         ) => {
-          if (error) return reject(error);
+          if (error) return reject(new Error(error.message));
           resolve(result);
         },
       );

--- a/src/modules/exam/dto/create-exam.dto.ts
+++ b/src/modules/exam/dto/create-exam.dto.ts
@@ -92,4 +92,3 @@ export class CreateExamDto {
   @Type(() => SettingsDto)
   settings: SettingsDto;
 }
-

--- a/src/modules/exam/models/exam.model.ts
+++ b/src/modules/exam/models/exam.model.ts
@@ -78,8 +78,8 @@ export class Exam {
   @Prop({ required: false })
   submissions: Array<Submissions>;
 
-  @Prop({ type: String, required: true })
-  question?: string;
+  @Prop({ type: [String], default: [] })
+  question_text: string[];
 
   @Prop({ type: Types.ObjectId, ref: 'User', required: true })
   lecturer: Types.ObjectId;

--- a/src/modules/process/docs/swagger.ts
+++ b/src/modules/process/docs/swagger.ts
@@ -14,6 +14,11 @@ export const ProcessControllerSwagger = {
 
   processPdf: applyDecorators(
     ApiOperation({ summary: 'Extract and parse questions from an exam PDF' }),
+    ApiParam({
+      name: 'examKey',
+      description: 'Key of the exam to attach parsed questions to',
+      schema: { type: 'string' },
+    }),
     ApiConsumes('multipart/form-data'),
     ApiBody({
       schema: {

--- a/src/modules/process/process.controller.ts
+++ b/src/modules/process/process.controller.ts
@@ -17,13 +17,14 @@ import { Express } from 'express';
 export class ProcessController {
   constructor(private readonly service: ProcessService) {}
 
-  @Post()
+  @Post(':examKey')
   @UseInterceptors(FileInterceptor('file'))
   @Docs.processPdf
   async processPdf(
     @UploadedFile() file: Express.Multer.File,
+    @Param('examKey') examKey: string,
   ): Promise<{ jobId: string | undefined }> {
-    return this.service.enqueueProcessPdf(file);
+    return this.service.enqueueProcessPdf(file, examKey);
   }
 
   @Post('mark/:examKey')

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,6 +8,7 @@ export enum PdfJobs {
 
 export interface ParseJobData {
   tmpPath: string;
+  examKey: string;
 }
 
 export interface MarkJobData extends ParseJobData {


### PR DESCRIPTION
## Summary
- store extracted question text on exams
- update parse service to save parsed questions to exams
- randomize questions for student login
- enhance PDF output with borders and header styling
- clean up error handling and lint issues

## Testing
- `npm run lint`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684307bd16d4832ebd1d32b5681453da