### PR TITLE
Record time spent and improve transcript

### DIFF
--- a/src/modules/exam/interfaces/exam.interface.ts
+++ b/src/modules/exam/interfaces/exam.interface.ts
@@ -3,6 +3,7 @@ export interface Submissions {
   studentAnswer: string;
   score: number;
   timeSubmitted: string;
+  timeSpent: number;
   transcript?: string;
 }
 

--- a/src/modules/process/process.controller.ts
+++ b/src/modules/process/process.controller.ts
@@ -35,9 +35,16 @@ export class ProcessController {
     @Param('examKey') examKey: string,
     @Query('email') email: string,
     @Query('studentAnswer') studentAnswer: string,
+    @Query('timeSpent') timeSpent: string,
   ): Promise<{ jobId: string | undefined; message: string }> {
     console.log('hit');
-    return this.service.enqueueMarkPdf(file, examKey, email, studentAnswer);
+    return this.service.enqueueMarkPdf(
+      file,
+      examKey,
+      email,
+      studentAnswer,
+      parseInt(timeSpent, 10) || 0,
+    );
   }
 
   @Get('job/:id')

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,4 +15,5 @@ export interface MarkJobData extends ParseJobData {
   examKey: string;
   email: string;
   studentAnswer: string;
+  timeSpent: number;
 }


### PR DESCRIPTION
## Summary
- add `timeSpent` field to submissions and job data
- accept `timeSpent` from query when marking
- store time spent in DB and display on transcript
- remove decorative borders from transcripts and support multi-page exam files

## Testing
- `yarn lint`
- `yarn test --passWithNoTests`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6845b5abb5dc832ebf65194c837a789d