### PR TITLE
Implement login event tracking

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { ExamModule } from './modules/exam/exam.module';
 import { JwtModule } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
 import { QueueModule } from './lib/queue/queue.module';
+import { EventsModule } from './lib/events/events.module';
 import 'dotenv/config';
 import { CloudinaryModule } from './lib/cloudinary/cloudinary.module';
 
@@ -31,6 +32,7 @@ import { CloudinaryModule } from './lib/cloudinary/cloudinary.module';
     ExamModule,
     QueueModule,
     CloudinaryModule,
+    EventsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/lib/events/events.constants.ts
+++ b/src/lib/events/events.constants.ts
@@ -1,0 +1,2 @@
+export const STUDENT_IN_EVENT = 'student-in';
+export const STUDENT_OUT_EVENT = 'student-out';

--- a/src/lib/events/events.module.ts
+++ b/src/lib/events/events.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { AppEvents } from './events.service';
+
+@Global()
+@Module({
+  providers: [AppEvents],
+  exports: [AppEvents],
+})
+export class EventsModule {}

--- a/src/lib/events/events.service.ts
+++ b/src/lib/events/events.service.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { EventEmitter } from 'events';
+
+@Injectable()
+export class AppEvents extends EventEmitter {}

--- a/src/modules/exam/exam.controller.ts
+++ b/src/modules/exam/exam.controller.ts
@@ -118,6 +118,14 @@ export class ExamController {
     return this.examService.studentLogin(key, email.email);
   }
 
+  @Post(':key/logout')
+  async studentLogout(
+    @Param('key') key: string,
+    @Body() email: { email: string },
+  ) {
+    return this.examService.studentLogout(key, email.email);
+  }
+
   @NeedsAuth()
   @Post(':id/send')
   async sendExamBack(

--- a/src/modules/exam/exam.service.ts
+++ b/src/modules/exam/exam.service.ts
@@ -12,7 +12,6 @@ import { CreateExamDto } from './dto/create-exam.dto';
 import { Invite } from './dto/invite-students.dto';
 import { User, UserDocument } from '../users/models/user.model';
 import { JwtService } from '@nestjs/jwt';
-import { Express } from 'express';
 import {
   returnEmails,
   returnNames,

--- a/src/modules/exam/exam.service.ts
+++ b/src/modules/exam/exam.service.ts
@@ -24,6 +24,11 @@ import { Queue } from 'bullmq';
 import { EXAM_SCHEDULER_QUEUE } from 'src/utils/constants';
 import { ProcessService } from '../process/process.service';
 import { writeFile } from 'node:fs/promises';
+import { AppEvents } from 'src/lib/events/events.service';
+import {
+  STUDENT_IN_EVENT,
+  STUDENT_OUT_EVENT,
+} from 'src/lib/events/events.constants';
 
 @Injectable()
 export class ExamService {
@@ -42,7 +47,19 @@ export class ExamService {
     @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
     private readonly jwtService: JwtService,
     private readonly processService: ProcessService,
-  ) {}
+    private readonly events: AppEvents,
+  ) {
+    this.events.on(STUDENT_IN_EVENT, (id: string) => {
+      this.handleStudentIn(id).catch((e) =>
+        this.logger.error('handleStudentIn', this.formatError(e)),
+      );
+    });
+    this.events.on(STUDENT_OUT_EVENT, (id: string) => {
+      this.handleStudentOut(id).catch((e) =>
+        this.logger.error('handleStudentOut', this.formatError(e)),
+      );
+    });
+  }
 
   async createExam(dto: CreateExamDto, file?: Express.Multer.File) {
     try {
@@ -368,8 +385,7 @@ export class ExamService {
         throw new BadRequestException('Email already submitted');
       }
 
-      exam.ongoing += 1;
-      await exam.save();
+      this.events.emit(STUDENT_IN_EVENT, exam._id.toString());
       const token = await this.jwtService.signAsync({
         email,
         mode: 'student',
@@ -411,6 +427,30 @@ export class ExamService {
         this.formatError(error),
       );
       throw new BadRequestException('Error during student login');
+    }
+  }
+
+  async studentLogout(examKey: string, email: string) {
+    try {
+      this.logger.log(
+        `Student logout attempt: examKey="${examKey}", email="${email}"`,
+      );
+      const exam = await this.examModel.findOne({ examKey }).exec();
+      if (!exam) {
+        this.logger.warn(`Exam not found in studentLogout: key="${examKey}"`);
+        throw new NotFoundException('Exam not found');
+      }
+      this.events.emit(STUDENT_OUT_EVENT, exam._id.toString());
+      return { message: 'Logout successful' };
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error(
+        `studentLogout failed for examKey="${examKey}", email="${email}"`,
+        this.formatError(error),
+      );
+      throw new BadRequestException('Error during student logout');
     }
   }
 
@@ -595,6 +635,16 @@ export class ExamService {
       );
       throw new BadRequestException('Failed to duplicate exam');
     }
+  }
+
+  private async handleStudentIn(examId: string) {
+    await this.examModel.updateOne({ _id: examId }, { $inc: { ongoing: 1 } });
+    this.logger.verbose(`Incremented ongoing count for exam ${examId}`);
+  }
+
+  private async handleStudentOut(examId: string) {
+    await this.examModel.updateOne({ _id: examId }, { $inc: { ongoing: -1 } });
+    this.logger.verbose(`Decremented ongoing count for exam ${examId}`);
   }
 
   async scheduleExam(examId: string, startAt: Date) {

--- a/src/modules/process/process.module.ts
+++ b/src/modules/process/process.module.ts
@@ -4,6 +4,7 @@ import { ProcessService } from './process.service';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Exam, ExamSchema } from '../exam/models/exam.model';
 import { QueueModule } from 'src/lib/queue/queue.module';
+import { CloudinaryService } from 'src/lib/cloudinary/cloudinary.service';
 
 @Module({
   imports: [
@@ -16,7 +17,7 @@ import { QueueModule } from 'src/lib/queue/queue.module';
     forwardRef(() => QueueModule),
   ],
   controllers: [ProcessController],
-  providers: [ProcessService],
+  providers: [ProcessService, CloudinaryService],
   exports: [ProcessService],
 })
 export class ProcessModule {}


### PR DESCRIPTION
## Summary
- add events module using Node EventEmitter
- hook student login/logout to emit events
- increment or decrement ongoing count via listeners
- wire up new student logout endpoint
- register EventsModule in root

## Testing
- `yarn lint`
- `yarn test --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6845bd102f04832e80dc55c9c623a809