### PR TITLE
Fix compile errors and update Zoho email support

### DIFF
--- a/src/modules/email/email.service.ts
+++ b/src/modules/email/email.service.ts
@@ -18,12 +18,12 @@ export class MailService {
 
   private buildTransport(): Transporter {
     return nodemailer.createTransport({
-      host: process.env.ZOHO_SMTP_HOST,
-      port: Number(process.env.ZOHO_SMTP_PORT) || 465,
+      host: this.cfg.get<string>('ZOHO_SMTP_HOST'),
+      port: this.cfg.get<number>('ZOHO_SMTP_PORT') ?? 465,
       secure: true,
       auth: {
-        user: process.env.ZOHO_USERNAME,
-        pass: process.env.ZOHO_APP_PASS,
+        user: this.cfg.get<string>('ZOHO_USERNAME'),
+        pass: this.cfg.get<string>('ZOHO_APP_PASS'),
       },
     });
   }

--- a/src/modules/exam/exam.controller.ts
+++ b/src/modules/exam/exam.controller.ts
@@ -152,7 +152,7 @@ export class ExamController {
   }
 
   @Post('login')
-  async studentLogin(
+  async studentLoginLegacy(
     @Body('email') email: string,
     @Body('examKey') examKey: string,
   ) {

--- a/src/modules/exam/models/exam.model.ts
+++ b/src/modules/exam/models/exam.model.ts
@@ -1,7 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, Types } from 'mongoose';
 import { ConfigService } from '@nestjs/config';
-import { SendgridService } from 'src/modules/email/email.service';
+import { MailService } from 'src/modules/email/email.service';
 import { Submissions } from '../interfaces/exam.interface';
 
 const cfg = new ConfigService();
@@ -10,6 +10,7 @@ export enum ExamAccessType {
   OPEN = 'open',
   PRIVATE = 'private',
   RESTRICTED = 'restricted',
+  SCHEDULED = 'scheduled',
 }
 
 @Schema({ _id: false })
@@ -78,7 +79,7 @@ export const ExamSchema = SchemaFactory.createForClass(Exam);
 ExamSchema.pre<ExamDocument>('save', async function (next) {
   if (this.isModified('invites')) {
     this.invites = this.invites.map((invite) => invite.toLowerCase());
-    const sg = new SendgridService(new ConfigService());
+    const sg = new MailService(new ConfigService());
     const URL: string = cfg.getOrThrow('URL');
     const link =
       this.link || `${URL}/student/${this.id as string}?mode=student`;

--- a/src/modules/process/process.service.ts
+++ b/src/modules/process/process.service.ts
@@ -99,6 +99,7 @@ Return ONLY the score as X/Y.`.trim();
       examKey,
       email,
       studentAnswer,
+      timeSpent: 0,
     });
     log.verbose(`Queued mark job ${job.id} for exam ${examKey} – ${email}`);
     return {
@@ -187,6 +188,8 @@ Return ONLY the score as X/Y.`.trim();
       email: email.toLowerCase(),
       studentAnswer,
       score: parseInt(scoreText.split('/')[0], 10),
+      timeSubmitted: new Date().toISOString(),
+      timeSpent: data.timeSpent ?? 0,
     };
     exam.submissions.push(submissions);
     await exam.save();
@@ -248,7 +251,7 @@ Return ONLY the score as X/Y.`.trim();
       .stroke();
 
     doc.end();
-    await new Promise((resolve) => stream.on('finish', resolve));
+    await new Promise<void>((resolve) => stream.on('finish', resolve));
     return filePath;
   }
 


### PR DESCRIPTION
## Summary
- fix compile errors in exam services and controllers
- add `SCHEDULED` access level for exams
- update email service to use Zoho credentials via `ConfigService`
- adjust PDF processing logic and typings

## Testing
- `npx tsc -p tsconfig.json`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_685ad5ed5124832e81cc663a021cad89