### PR TITLE
Handle write stream errors in PDF generation

### DIFF
--- a/src/modules/process/process.service.ts
+++ b/src/modules/process/process.service.ts
@@ -274,7 +274,10 @@ Return ONLY the JSON array—no markdown fences, no extra text.`.trim();
       .stroke();
 
     doc.end();
-    await new Promise<void>((resolve) => stream.on('finish', resolve));
+    await new Promise<void>((resolve, reject) => {
+      stream.on('finish', resolve);
+      stream.on('error', reject);
+    });
     return filePath;
   }
 


### PR DESCRIPTION
## Summary
- handle write stream `error` events so PDF generation jobs fail fast

## Testing
- `yarn test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba85e0f88832e9b88b429245c1cd6