### PR TITLE
Enable agentless Datadog tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Provide these environment variables when running in production:
 - `DD_AGENT_HOST` – Datadog agent hostname
 - `DD_TRACE_AGENT_PORT` – Datadog agent port (defaults to `8126`)
 
+If you are not running a Datadog agent, provide these variables instead to send
+traces directly to Datadog:
+
+- `DD_API_KEY` – Datadog API key
+- `DD_SITE` – Datadog site domain (defaults to `datadoghq.com`)
+- `DD_TRACE_AGENT_URL` – optional custom trace intake URL
+
 Errors logged through the application logger are attached to the current trace span with full stack information.
 
 ## Deployment

--- a/src/lib/tracing/tracing.ts
+++ b/src/lib/tracing/tracing.ts
@@ -1,12 +1,25 @@
 import ddTrace from 'dd-trace';
 
-const tracer = ddTrace.init({
+const options: Record<string, any> = {
   service: process.env.DD_SERVICE || 'exam-mod-be',
   env: process.env.DD_ENV || process.env.NODE_ENV || 'development',
   version: process.env.npm_package_version || '0.0.1',
   logInjection: true,
   runtimeMetrics: true,
   profiling: true,
-});
+};
+
+// When no local Datadog agent is available, forward traces directly to Datadog's
+// public intake. This requires an API key.
+const apiKey = process.env.DD_API_KEY;
+if (apiKey) {
+  const site = process.env.DD_SITE || 'datadoghq.com';
+  options.url = process.env.DD_TRACE_AGENT_URL || `https://trace.agent.${site}`;
+  options.headers = {
+    'DD-API-KEY': apiKey,
+  };
+}
+
+const tracer = ddTrace.init(options);
 
 export default tracer;


### PR DESCRIPTION
## Summary
- configure Datadog tracer for agentless mode when `DD_API_KEY` is provided
- document agentless Datadog environment variables

## Testing
- `yarn lint` *(fails: '@typescript-eslint/no-base-to-string' and '@typescript-eslint/no-unsafe-assignment')*
- `yarn test --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6862cc7288f0832e8576cafa4a74a664