### PR TITLE
Add error logging for pdf parse worker

### DIFF
--- a/src/modules/process/process.service.ts
+++ b/src/modules/process/process.service.ts
@@ -223,6 +223,10 @@ Rules:
       }
 
       return parsed;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.logger.error(`Error in parsePdfWorker: ${JSON.stringify(msg)}`);
+      throw e;
     } finally {
       await unlink(tmpPath);
     }


### PR DESCRIPTION
## Summary
- log errors in `parsePdfWorker`

## Testing
- `yarn test --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68679c018b70832eb1ca145e952e6f9a