### PR TITLE
Improve PDF worker reliability

### DIFF
--- a/src/lib/queue/queue.consumer.ts
+++ b/src/lib/queue/queue.consumer.ts
@@ -33,7 +33,7 @@ export class PdfQueueConsumer extends WorkerHost {
       switch (job.name as PdfJobs) {
         case PdfJobs.PROCESS:
           this.log.debug(`Parsing PDF for job ${job.id}`);
-          return this.processSvc.parsePdfWorker(job.data as ParseJobData);
+          return this.processSvc.parsePdfWorker(job as Job<ParseJobData>);
 
         case PdfJobs.MARK:
           this.log.debug(`Marking PDF for job ${job.id}`);


### PR DESCRIPTION
## Summary
- retain temp files across job retries
- detect `pdftotext` command before using it
- log retry status in parse worker

## Testing
- `yarn lint`
- `yarn test --passWithNoTests`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6867a6b62ee0832e91e2dcf2a4c79c48